### PR TITLE
Add CI workflow + note deferred env-invariant perf gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL (for pytest-postgresql's pg_ctl)
+        # tests/conftest.py points pytest-postgresql at /usr/bin/pg_ctl (the
+        # path the developer host has on Fedora). Ubuntu runners install
+        # pg_ctl under /usr/lib/postgresql/<n>/bin/, so symlink it into
+        # /usr/bin to keep the conftest portable across both layouts.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql
+          sudo ln -sf "$(ls /usr/lib/postgresql/*/bin/pg_ctl | head -1)" /usr/bin/pg_ctl
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: uv sync
+        run: uv sync --all-extras
+
+      - name: ruff check
+        run: uv run ruff check .
+
+      - name: ruff format --check
+        run: uv run ruff format --check .
+
+      - name: mypy
+        run: uv run mypy src
+
+      - name: pytest
+        run: uv run pytest
+
+      # SC-006 --baseline-compare is intentionally NOT run in CI: baseline.json
+      # was recorded against the developer host hardware (per its ``host``
+      # block); GitHub-hosted runners are commodity but slower, so a CI
+      # comparison can fail without a real regression. The bench remains a
+      # developer-machine gate.

--- a/specs/001-modernize-stack/tasks.md
+++ b/specs/001-modernize-stack/tasks.md
@@ -287,6 +287,11 @@ After Phase 4 completes, US3, US4, and US5 are mutually independent. Three devel
 
 ---
 
+## Deferred / Future Work
+
+- **T030** (manual end-to-end menu walk) is deferred to an operator session — only outstanding task. Annotated in commit `6f08fb8`.
+- **CI performance gate**: `.github/workflows/ci.yml` deliberately does *not* run `--baseline-compare`. `tests/benchmarks/baseline.json` was recorded against the developer host; GitHub-hosted runners are commodity but slower, so a CI comparison can fail without any real regression. The bench stays a developer-machine gate. Future work: replace the wall-clock comparison with an *environment-invariant* perf signal — e.g. SQLAlchemy query-count budgets per op (catches accidental N+1 regressions without depending on host speed) or an algorithmic-complexity assertion on the search/insert paths. Either would fit a CI gate cleanly and would tighten Principle IV's "no measurable regression" predicate without re-introducing the host-hardware coupling baseline.json embeds.
+
 ## Notes
 
 - [P] tasks = different files, no incomplete dependencies.


### PR DESCRIPTION
GitHub Actions workflow runs the four merge gates on push to main and on PRs: ``ruff check``, ``ruff format --check``, ``mypy src``, ``pytest``. pytest-postgresql needs ``pg_ctl`` on the path; the workflow installs ``postgresql`` and symlinks the Ubuntu binary into ``/usr/bin`` so ``tests/conftest.py``'s Fedora-tuned hardcode keeps working unchanged.

The SC-006 ``--baseline-compare`` is deliberately *not* run in CI: ``baseline.json`` was recorded on the developer host, and GitHub-hosted runners are slower commodity hardware, so a CI comparison can fail without a real regression. Documented in the workflow file and added a "Deferred / Future Work" entry to ``specs/001-modernize-stack/tasks.md`` proposing an environment-invariant signal (SQLAlchemy query-count budget or algorithmic-complexity assertion) as a future replacement.